### PR TITLE
Corrige URL do webhook para geração de legendas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,8 @@ const platforms: Platform[] = [
   { id: 'whatsapp', name: 'WhatsApp', icon: MessageCircle, color: 'text-green-500' },
 ];
 
-const WEBHOOK_URL = 'https://n8n.nexladesenvolvimento.com.br/webhook/LinkTeste';
+// Webhook utilizado para gerar as legendas
+const WEBHOOK_URL = 'https://n8n.nexladesenvolvimento.com.br/webhook/frase';
 
 function App() {
   const [selectedPlatform, setSelectedPlatform] = useState<string>('');
@@ -84,7 +85,7 @@ function App() {
         throw new Error('Não foi possível registrar o pedido');
       }
 
-      const response = await fetch('https://n8n.nexladesenvolvimento.com.br/webhook-test/LinkTeste', {
+      const response = await fetch(WEBHOOK_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- update webhook URL for caption generation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8ca69f08325980bb9c40193d1d4